### PR TITLE
add basic documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,11 @@
 # sys.path.insert(0, os.path.abspath('.'))
 
 import datetime as dt
+import pathlib
+import site
+
+here = pathlib.Path(__file__).absolute().parent
+site.addsitedir(str(here))
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,8 +33,14 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.autosummary",
     "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
     "accessors",
 ]
+
+autosummary_generate = True
+
+napoleon_use_param = True
+napoleon_use_rtype = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -55,7 +61,7 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# html_static_path = ["_static"]
 
 
 # -- Extension configuration -------------------------------------------------

--- a/docs/example.py
+++ b/docs/example.py
@@ -1,0 +1,49 @@
+class CachedAccessor:
+    def __init__(self, name, accessor):
+        self._name = name
+        self._accessor = accessor
+
+    def __get__(self, obj, cls):
+        if obj is None:
+            return self._accessor
+
+        accessor_obj = self._accessor(obj)
+        setattr(obj, self._name, accessor_obj)
+
+        return accessor_obj
+
+
+class Example:
+    def __init__(self, data):
+        self._data = data
+
+
+def register_accessor(name):
+    def func(accessor):
+        setattr(Example, name, CachedAccessor(name, accessor))
+
+        return accessor
+
+    return func
+
+
+@register_accessor("test")
+class TestAccessor:
+    def __init__(self, obj):
+        self._obj = obj
+
+    @property
+    def double(self):
+        """ double the data """
+        return self.multiply(2)
+
+    def multiply(self, factor):
+        """ multiply data with a factor
+
+        Parameters
+        ----------
+        factor : int
+            The factor for the multiplication
+        """
+
+        return self._obj._data * factor

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,20 +1,66 @@
-.. accessors documentation master file, created by
-   sphinx-quickstart on Wed Jul  1 01:14:01 2020.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+accessors
+=========
+`accessors` is a `sphinx` extension to properly document `pandas`_ or
+`xarray`_ style accessors using `autosummary`_ and `autodoc`_.
 
-Welcome to accessors's documentation!
-=====================================
+`autosummary`_ is able to create summary and detail pages for objects
+and their methods, but its doesn't work well with accessor styled
+properties and methods (``obj.accessor.attribute``). `pandas`_ has
+accessor documentation build using `autosummary`_ templates, which
+`xarray`_ recently adopted by copying the templates and all related
+code.
 
-.. toctree::
-   :maxdepth: 2
-   :caption: Contents:
+To avoid even more duplicated code, and to make it easier for projects
+to document their custom accessors, this package aims to make this as
+simple as adding ``"accessors"`` to the ``extensions`` setting in
+``conf.py``:
 
+.. code:: python
 
+    extensions = [
+       ...,
+       "accessors",
+       ...,
+    ]
 
-Indices and tables
-==================
+Then, we can simply add a template option to the `autosummary`_
+directives to get summary and detail pages:
 
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+.. code:: rst
+
+   .. currentmodule:: example
+
+   .. autosummary::
+      :toctree: generated/
+      :template: accessor_attribute.rst
+
+      Example.test.double
+
+   .. autosummary::
+      :toctree: generated/
+      :template: accessor_method.rst
+
+      Example.test.multiply
+   
+
+will become:
+
+.. currentmodule:: example
+
+.. autosummary::
+    :toctree: generated/
+    :template: accessor_attribute.rst
+
+    Example.test.double
+
+.. autosummary::
+    :toctree: generated/
+    :template: accessor_method.rst
+
+    Example.test.multiply
+
+.. _sphinx: https://www.sphinx-doc.org
+.. _pandas: https://pandas.pydata.org
+.. _xarray: https://xarray.pydata.org
+.. _autodoc: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
+.. _autosummary: https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx
-xarray
+sphinx>3
+sphinx_rtd_theme


### PR DESCRIPTION
Right now, this only demonstrates the use of the extension instead of documenting the accessor templates / documenter classes, so that's something that still needs to be done.